### PR TITLE
add weather location and last update

### DIFF
--- a/16x9/MyWeather.xml
+++ b/16x9/MyWeather.xml
@@ -31,6 +31,35 @@
 		<!-- Time -->
 		<include>Time</include>
 
+
+		<!--location, last update -->
+		<control type="group">
+			<left>30</left>
+			<top>30</top> 
+			<control type="label">
+					<description>weather location label</description>
+					<left>30</left>
+					<top>30</top>
+					<width>1600</width>
+					<height>44</height>
+					<font>Small</font>
+					<textcolor>ColorHeading</textcolor>
+					<scroll>false</scroll>
+					<label>$INFO[Window.Property(Location)]</label>
+			</control>
+			<control type="label">
+					<description>update label</description>
+					<left>30</left>
+					<top>82</top>
+					<width>1600</width>
+					<height>44</height>
+					<font>XSmall</font>
+					<label>$LOCALIZE[31301]: $INFO[Window.Property(Updated)]</label>
+					<textcolor>ColorDetails</textcolor>
+			</control>
+		</control>
+
+
 		<!-- Main group -->
 		<control type="group">
 			<include>WindowFadeAnimation</include>
@@ -171,7 +200,7 @@
 			<!-- Weather Info -->
 			<control type="group">
 				<left>420</left>
-				<top>438</top>
+				<top>438</top> 
 				<control type="label">
 					<left>0</left>
 					<top>314</top>
@@ -210,6 +239,7 @@
 					<autoscroll>false</autoscroll>
 				</control>
 			</control>
+
 
 			<!-- Weather provider -->
 			<control type="grouplist">

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -249,3 +249,7 @@ msgstr ""
 msgctxt "#31067"
 msgid "My OSMC"
 msgstr ""
+
+msgctxt "#31301"
+msgid "Last updated"
+msgstr ""


### PR DESCRIPTION
Minor changes to Weather page. Added display of current location and
last updated time. Previously, user had no visible indication which city
was active, or if the data was stale. See here for example:
https://discourse.osmc.tv/t/show-city-on-weather-menu/5630/4
